### PR TITLE
Add support for TEST_CUSTOM_CHECKS env var in CLI installer test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -79,5 +79,6 @@ passenv =
   TEST_CREATE_CLUSTER
   TEST_CLUSTER_INFO_PATH
   TEST_INSTALL_PREREQS
+  TEST_CUSTOM_CHECKS
   TEAMCITY_VERSION
 commands = py.test {posargs} test_installer_cli.py


### PR DESCRIPTION
This will cause `test_installer_cli()` to add a custom check executable and define a custom check that uses it.

See https://github.com/dcos/dcos/pull/1914