### PR TITLE
Updating advanced-tests to point to the changed skip-checks SHA.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-git+https://github.com/dcos/dcos-test-utils.git@449eb8018468c0eafbc85342b68639ac89e8f6be
+git+https://github.com/dcos/dcos-test-utils.git@e96d09456377d30450069dc1efaa818357f4d892
 git+https://github.com/dcos/dcos-launch.git@40bcef8ba9975f8fba6f86d2fc212d1a5f323db8
 pytest
 retrying

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -474,3 +474,14 @@ class TestUpgrade:
             'Hostname failed to resolve at these times:\n{failures}'.format(
                 hostname=dns_app['env']['RESOLVE_NAME'],
                 failures='\n'.join(dns_failure_times))
+
+    def test_oauth_enabled(self, upgraded_dcos):
+        # Verifies configuration change when upgrading for Open DC/OS.
+        # oauth_enabled is set to 'true' before the upgrade and should be set to 
+        # 'false' after the upgrade to disable authentication.
+        response = upgraded_dcos.get('dcos-metadata/ui-config.json')
+        response.raise_for_status()
+        oauth = response.json()["uiConfiguration"]["plugins"]["oauth"]["enabled"]
+        assert oauth == False
+
+

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -474,14 +474,3 @@ class TestUpgrade:
             'Hostname failed to resolve at these times:\n{failures}'.format(
                 hostname=dns_app['env']['RESOLVE_NAME'],
                 failures='\n'.join(dns_failure_times))
-
-    def test_oauth_enabled(self, upgraded_dcos):
-        # Verifies configuration change when upgrading for Open DC/OS.
-        # oauth_enabled is set to 'true' before the upgrade and should be set to 
-        # 'false' after the upgrade to disable authentication.
-        response = upgraded_dcos.get('dcos-metadata/ui-config.json')
-        response.raise_for_status()
-        oauth = response.json()["uiConfiguration"]["plugins"]["oauth"]["enabled"]
-        assert oauth == False
-
-


### PR DESCRIPTION
Pointing advanced-tests to the correct --skip-checks change in dcos-test-utils for the disabled -> permissive upgrade test.