### PR TITLE
Bumped 1.8 version.

### DIFF
--- a/.advancedtestsrc
+++ b/.advancedtestsrc
@@ -2,13 +2,13 @@
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.8.9/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.8.10/dcos_generate_config.sh
 
 [upgrade-from-1.8-ee]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.8.9/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.8.10/dcos_generate_config.ee.sh
 
 [upgrade-to-1.9-open]
 TEST_UPGRADE_USE_CHECKS=false


### PR DESCRIPTION
Since DC/OS 1.8.10 is now the latest stable release for 1.8, need to update the upgrade test installer urls to DC/OS 1.8.10.