### PR TITLE
Bumping version to 1.10.2

### DIFF
--- a/.advancedtestsrc
+++ b/.advancedtestsrc
@@ -38,25 +38,25 @@ TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.1/dcos_generate_config.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.2/dcos_generate_config.sh
 
 [upgrade-to-1.10-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.1/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.2/dcos_generate_config.ee.sh
 
 [upgrade-from-1.10-open]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.1/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.2/dcos_generate_config.sh
 
 [upgrade-from-1.10-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.1/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.2/dcos_generate_config.ee.sh
 
 [upgrade-from-master-open]
 TEST_UPGRADE_USE_CHECKS=true


### PR DESCRIPTION
Since DC/OS 1.10.2 is now the latest stable release for 1.10, need to update the upgrade test installer urls to DC/OS 1.10.2.