### PR TITLE
Bumping versions to 1.10.3 (EE only) & 1.9.6

### DIFF
--- a/.advancedtestsrc
+++ b/.advancedtestsrc
@@ -14,25 +14,25 @@ TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=false
-TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.5/dcos_generate_config.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.6/dcos_generate_config.sh
 
 [upgrade-to-1.9-ee]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.5/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.6/dcos_generate_config.ee.sh
 
 [upgrade-from-1.9-open]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.5/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.6/dcos_generate_config.sh
 
 [upgrade-from-1.9-ee]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.5/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.6/dcos_generate_config.ee.sh
 
 [upgrade-to-1.10-open]
 TEST_UPGRADE_USE_CHECKS=true
@@ -44,7 +44,7 @@ TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.2/dcos_gen
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.2/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.3/dcos_generate_config.ee.sh
 
 [upgrade-from-1.10-open]
 TEST_UPGRADE_USE_CHECKS=true
@@ -56,7 +56,7 @@ TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.2/dc
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.2/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.3/dcos_generate_config.ee.sh
 
 [upgrade-to-1.11-open]
 TEST_UPGRADE_USE_CHECKS=true


### PR DESCRIPTION
Since DC/OS 1.10.3 is now the latest EE stable release for 1.10, need to update the Enterprise installer urls to DC/OS 1.10.3.

Also updating the 1.9 installer urls to point to 1.9.6 (latest stable release).