### PR TITLE
Bumping DC/OS versions to 1.9.8, 1.10.6, & 1.11.1

### DIFF
--- a/.advancedtestsrc
+++ b/.advancedtestsrc
@@ -14,73 +14,73 @@ TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=false
-TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.7/dcos_generate_config.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.8/dcos_generate_config.sh
 
 [upgrade-to-1.9-ee]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.7/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.8/dcos_generate_config.ee.sh
 
 [upgrade-from-1.9-open]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.7/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.8/dcos_generate_config.sh
 
 [upgrade-from-1.9-ee]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.7/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.8/dcos_generate_config.ee.sh
 
 [upgrade-to-1.10-open]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.5/dcos_generate_config.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.6/dcos_generate_config.sh
 
 [upgrade-to-1.10-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.5/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.6/dcos_generate_config.ee.sh
 
 [upgrade-from-1.10-open]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.5/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.6/dcos_generate_config.sh
 
 [upgrade-from-1.10-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.5/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.6/dcos_generate_config.ee.sh
 
 [upgrade-to-1.11-open]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.11.0/dcos_generate_config.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.11.1/dcos_generate_config.sh
 
 [upgrade-to-1.11-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=http://downloads.mesosphere.com/dcos-enterprise/stable/1.11.0/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=http://downloads.mesosphere.com/dcos-enterprise/stable/1.11.1/dcos_generate_config.ee.sh
 
 [upgrade-from-1.11-open]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.11.0/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.11.1/dcos_generate_config.sh
 
 [upgrade-from-1.11-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=http://downloads.mesosphere.com/dcos-enterprise/stable/1.11.0/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=http://downloads.mesosphere.com/dcos-enterprise/stable/1.11.1/dcos_generate_config.ee.sh
 
 [upgrade-from-master-open]
 TEST_UPGRADE_USE_CHECKS=true


### PR DESCRIPTION
Updating upgrading scenarios to include the latest stable releases for 1.9, 1.10, & 1.11.