### PR TITLE
Updated for 1.10.7 & 1.9.9

### DIFF
--- a/.advancedtestsrc
+++ b/.advancedtestsrc
@@ -14,25 +14,25 @@ TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=false
-TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.8/dcos_generate_config.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.9/dcos_generate_config.sh
 
 [upgrade-to-1.9-ee]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=false
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.8/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.9/dcos_generate_config.ee.sh
 
 [upgrade-from-1.9-open]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.8/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.9.9/dcos_generate_config.sh
 
 [upgrade-from-1.9-ee]
 TEST_UPGRADE_USE_CHECKS=false
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.8/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.9.9/dcos_generate_config.ee.sh
 
 [upgrade-to-1.10-open]
 TEST_UPGRADE_USE_CHECKS=true

--- a/.advancedtestsrc
+++ b/.advancedtestsrc
@@ -38,25 +38,25 @@ TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.6/dcos_generate_config.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.7/dcos_generate_config.sh
 
 [upgrade-to-1.10-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.6/dcos_generate_config.ee.sh
+TEST_UPGRADE_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.7/dcos_generate_config.ee.sh
 
 [upgrade-from-1.10-open]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=false
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.6/dcos_generate_config.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/1.10.7/dcos_generate_config.sh
 
 [upgrade-from-1.10-ee]
 TEST_UPGRADE_USE_CHECKS=true
 TEST_UPGRADE_USE_PODS=true
 TEST_UPGRADE_ENTERPRISE=true
-TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.6/dcos_generate_config.ee.sh
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.mesosphere.io/dcos-enterprise/stable/1.10.7/dcos_generate_config.ee.sh
 
 [upgrade-to-1.11-open]
 TEST_UPGRADE_USE_CHECKS=true


### PR DESCRIPTION
1.10.7 & 1.9.9 are the latest GA releases for 1.9 & 1.10.