### PR TITLE
Dcos 39587 cassandra kafka spark mixed workload test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-git+https://github.com/dcos/dcos-test-utils.git@feddc854f172e927cdc3e99c47486f5133b3052b
+git+https://github.com/dcos/dcos-test-utils.git@c9a4fc583a4a0bca18040ad4c7772e187e51aa74
 git+https://github.com/dcos/dcos-launch.git@a7213b15d26994c5e10ffc36b941cbd270c939c7
 pytest
 retrying

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-git+https://github.com/dcos/dcos-test-utils.git@0caaec6e3bbbae44e3cb24011ac70a094552c526
+git+https://github.com/dcos/dcos-test-utils.git@feddc854f172e927cdc3e99c47486f5133b3052b
 git+https://github.com/dcos/dcos-launch.git@a7213b15d26994c5e10ffc36b941cbd270c939c7
 pytest
 retrying

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-git+https://github.com/dcos/dcos-test-utils.git@c9a4fc583a4a0bca18040ad4c7772e187e51aa74
+git+https://github.com/dcos/dcos-test-utils.git@0caaec6e3bbbae44e3cb24011ac70a094552c526
 git+https://github.com/dcos/dcos-launch.git@a7213b15d26994c5e10ffc36b941cbd270c939c7
 pytest
 retrying

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-git+https://github.com/dcos/dcos-test-utils.git@c9a4fc583a4a0bca18040ad4c7772e187e51aa74
+git+https://github.com/dcos/dcos-test-utils.git@feddc854f172e927cdc3e99c47486f5133b3052b
 git+https://github.com/dcos/dcos-launch.git@a7213b15d26994c5e10ffc36b941cbd270c939c7
 pytest
 retrying

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -406,6 +406,8 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
     for package in app_ids.keys():
         assert dcos_api_session.marathon.check_app_instances(app_ids[package], 1, True, False) is True
 
+    time.sleep(300)
+
     # Preserve the current quantity of words from the Kafka job so we can
     kafka_job_words = dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())
 

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -386,6 +386,10 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
     dcos_api_session.marathon.wait_for_deployments_complete()
     log.info("Completed installing required services.")
 
+    dcoscli.exec_command("dcos package install cassandra --cli".split())
+    dcoscli.exec_command("dcos package install kafka --cli".split())
+    dcoscli.exec_command("dcos package install spark --cli".split())
+
     dcoscli.exec_command(["dcos", "cassandra", "plan", "status", "deploy", "--json"])
     dcoscli.exec_command(["dcos", "cassandra", "plan", "status", "recovery", "--json"])
     dcoscli.exec_command(["dcos", "kafka", "plan", "status", "deploy", "--json"])

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -345,7 +345,7 @@ def wait_for_individual_framework_to_deploy(dcoscli, cli_commands):
         count += 1
 
 def wait_for_spark_job_to_deploy(dcoscli, run_command_response):
-    driver_name = run_command_response[run_command_response.index('driver-'):]
+    driver_name = str(run_command_response[0])[str(run_command_response[0]).index('driver-'):]
 
     status_command_response = dcoscli.exec_command(("dcos spark status " + driver_name).split())
 

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -337,7 +337,7 @@ def wait_for_individual_framework_to_deploy(dcoscli, cli_commands):
 
     count = 0
 
-    while (str(cassandra_deploy_json_return_string["status"]) != str("COMPLETE") and count < 60):
+    while (str(cassandra_deploy_json_return_string["status"]) != str("COMPLETE") and count <= 120):
         log.info("Waiting for '" + str(cli_commands) + "' to complete deploying - Attempt: " + str(count))
         time.sleep(5)
         cassandra_deploy_json_return_string = json.loads(

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -409,7 +409,7 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
     time.sleep(180)
 
     # Preserve the current quantity of words from the Kafka job so we can
-    kafka_job_words = json.loads(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split()))[0]["0"]
+    kafka_job_words = json.loads(str(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())))[0]["0"]
 
     # TODO(branden): We ought to be able to deploy these apps concurrently. See
     # https://mesosphere.atlassian.net/browse/DCOS-13360.
@@ -576,6 +576,6 @@ class TestUpgrade:
             assert dcos_api_session.marathon.check_app_instances(framework_ids[package], 1, True, False) is True
 
         # Preserve the current quantity of words from the Kafka job so we can
-        kafka_job_words_post_upgrade = json.loads(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split()))[0]["0"]
+        kafka_job_words_post_upgrade = json.loads(str(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())))[0]["0"]
 
         assert len(kafka_job_words_post_upgrade) > len(kafka_job_words)

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -261,7 +261,7 @@ def dcos_api_session(onprem_cluster, launcher, is_enterprise):
     return make_dcos_api_session(
         onprem_cluster, launcher, is_enterprise, launcher.config['dcos_config'].get('security'))
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def new_dcos_cli() -> Generator[dcos_cli.DcosCli, None, None]:
     cli = dcos_cli.DcosCli.new_cli()
     yield cli

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -335,11 +335,14 @@ def wait_for_individual_framework_to_deploy(dcoscli, cli_commands):
     cassandra_deploy_json_return_string = json.loads(
         dcoscli.exec_command(cli_commands.split())[0])
 
-    while (str(cassandra_deploy_json_return_string["status"]) != str("COMPLETE")):
+    count = 0
+
+    while (str(cassandra_deploy_json_return_string["status"]) != str("COMPLETE") and count < 60):
         log.info("Waiting for '" + str(cli_commands) + "' to complete deploying")
         time.sleep(5)
         cassandra_deploy_json_return_string = json.loads(
             dcoscli.exec_command(cli_commands.split())[0])
+        count += 1
 
 
 @pytest.fixture(scope='session')

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -349,9 +349,11 @@ def wait_for_spark_job_to_deploy(dcoscli, run_command_response):
 
     status_command_response = dcoscli.exec_command(("dcos spark status " + driver_name).split())
 
+    log.info(status_command_response)
+
     count = 0
 
-    while (status_command_response.find("state: TASK_RUNNING") == -1 and count <= 36):
+    while (''.join(status_command_response).find("state: TASK_RUNNING") == -1 and count <= 36):
         log.info("Waiting for '" + str(driver_name) + "' to complete deploying - Attempt: " + str(count))
         time.sleep(5)
         status_command_response = dcoscli.exec_command(("dcos spark status " + driver_name).split())

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -371,9 +371,9 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
 
     # Add essential services for basic run test
     services = {
-        'cassandra': {'version': os.environ.get('CASSANDRA_VERSION'), 'option': "--yes"},
-        'kafka': {'version': os.environ.get('KAFKA_VERSION'), 'option': "--yes"},
-        'spark': {'version': os.environ.get('SPARK_VERSION'), 'option': "--yes"}
+        'cassandra': {'version': os.environ.get('CASSANDRA_VERSION'), 'option': None},
+        'kafka': {'version': os.environ.get('KAFKA_VERSION'), 'option': None},
+        'spark': {'version': os.environ.get('SPARK_VERSION'), 'option': None}
     }
 
     for package, config in services.items():

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -338,7 +338,7 @@ def wait_for_individual_framework_to_deploy(dcoscli, cli_commands):
     count = 0
 
     while (str(cassandra_deploy_json_return_string["status"]) != str("COMPLETE") and count < 60):
-        log.info("Waiting for '" + str(cli_commands) + "' to complete deploying")
+        log.info("Waiting for '" + str(cli_commands) + "' to complete deploying - Attempt: " + str(count))
         time.sleep(5)
         cassandra_deploy_json_return_string = json.loads(
             dcoscli.exec_command(cli_commands.split())[0])
@@ -380,10 +380,10 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
 
     wait_for_frameworks_to_deploy(dcoscli)
 
-    dcoscli.exec_command("dcos spark run --submit-args=" + spark_producer_job())
+    dcoscli.exec_command_as_shell("dcos spark run --submit-args=" + spark_producer_job())
     dcos_api_session.marathon.wait_for_deployments_complete()
 
-    dcoscli.exec_command("dcos spark run --submit-args=" + spark_consumer_job())
+    dcoscli.exec_command_as_shell("dcos spark run --submit-args=" + spark_consumer_job())
     dcos_api_session.marathon.wait_for_deployments_complete()
 
     # Checking whether applications are running without errors.

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -406,10 +406,10 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
     for package in framework_ids.keys():
         assert dcos_api_session.marathon.check_app_instances(framework_ids[package], 1, True, False) is True
 
-    time.sleep(60)
+    time.sleep(180)
 
     # Preserve the current quantity of words from the Kafka job so we can
-    kafka_job_words = dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())
+    kafka_job_words = json.loads(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split()))[0]["0"]
 
     # TODO(branden): We ought to be able to deploy these apps concurrently. See
     # https://mesosphere.atlassian.net/browse/DCOS-13360.
@@ -576,6 +576,6 @@ class TestUpgrade:
             assert dcos_api_session.marathon.check_app_instances(framework_ids[package], 1, True, False) is True
 
         # Preserve the current quantity of words from the Kafka job so we can
-        kafka_job_words_post_upgrade = dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())
+        kafka_job_words_post_upgrade = json.loads(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split()))[0]["0"]
 
         assert len(kafka_job_words_post_upgrade) > len(kafka_job_words)

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -568,7 +568,7 @@ class TestUpgrade:
                 hostname=dns_app['env']['RESOLVE_NAME'],
                 failures='\n'.join(dns_failure_times))
 
-    def test_cassandra_tasks_survive(self, dcos_api_session, setup_workload):
+    def test_cassandra_tasks_survive(self, dcos_api_session, setup_workload, dcoscli):
         test_app_ids, test_pod_ids, tasks_start, task_state_start, kafka_job_words, framework_ids = setup_workload
 
         # Checking whether applications are running without errors.

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -406,10 +406,10 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
     for package in framework_ids.keys():
         assert dcos_api_session.marathon.check_app_instances(framework_ids[package], 1, True, False) is True
 
-    time.sleep(180)
+    time.sleep(300)
 
     # Preserve the current quantity of words from the Kafka job so we can
-    kafka_job_words = json.loads(str(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())))[0]["0"]
+    kafka_job_words = json.loads(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())[0])[0]["0"]
 
     # TODO(branden): We ought to be able to deploy these apps concurrently. See
     # https://mesosphere.atlassian.net/browse/DCOS-13360.
@@ -576,6 +576,6 @@ class TestUpgrade:
             assert dcos_api_session.marathon.check_app_instances(framework_ids[package], 1, True, False) is True
 
         # Preserve the current quantity of words from the Kafka job so we can
-        kafka_job_words_post_upgrade = json.loads(str(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())))[0]["0"]
+        kafka_job_words_post_upgrade = json.loads(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())[0])[0]["0"]
 
         assert len(kafka_job_words_post_upgrade) > len(kafka_job_words)

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -373,7 +373,9 @@ def wait_for_kafka_topic_to_start_counting(dcoscli):
 
     count = 0
 
-    while (kafka_job_words == 0 and count <= 60):
+    log.info("Recieved: '" + kafka_job_words + "' which is equal to 0: '" + str(kafka_job_words) == "0" + "'")
+
+    while (str(kafka_job_words) == "0" and count <= 60):
         log.info("Waiting for the kafka topic 'mytopicC' to begin counting words - Attempt: " + str(count))
         time.sleep(5)
         kafka_job_words = json.loads(dcoscli.exec_command("dcos kafka topic offsets mytopicC".split())[0])[0]["0"]

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -380,10 +380,10 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
 
     wait_for_frameworks_to_deploy(dcoscli)
 
-    dcoscli.exec_command_as_shell("dcos spark run --submit-args=" + spark_producer_job())
+    dcoscli.exec_command("dcos spark run --submit-args=" + spark_producer_job())
     dcos_api_session.marathon.wait_for_deployments_complete()
 
-    dcoscli.exec_command_as_shell("dcos spark run --submit-args=" + spark_consumer_job())
+    dcoscli.exec_command("dcos spark run --submit-args=" + spark_consumer_job())
     dcos_api_session.marathon.wait_for_deployments_complete()
 
     # Checking whether applications are running without errors.

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -25,6 +25,7 @@ import math
 import os
 import pprint
 import uuid
+from typing import Generator
 
 from dcos_test_utils import dcos_api, enterprise, helpers, dcos_cli
 import pytest
@@ -259,6 +260,13 @@ def dcos_api_session(onprem_cluster, launcher, is_enterprise):
     """
     return make_dcos_api_session(
         onprem_cluster, launcher, is_enterprise, launcher.config['dcos_config'].get('security'))
+
+@pytest.fixture
+def new_dcos_cli() -> Generator[dcos_cli.DcosCli, None, None]:
+    cli = dcos_cli.DcosCli.new_cli()
+    yield cli
+    os.remove(cli.path)
+    cli.clear_cli_dir()
 
 @pytest.fixture(scope='session')
 def dcoscli(

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -363,8 +363,7 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
     dcos_api_session.wait_for_dcos()
 
     # Installing dcos-enterprise-cli.
-    dcos_api_session.cosmos.install_package('dcos-enterprise-cli', os.environ.get('DCOS-ENTERPRISE-CLI_VERSION'),
-                                                 None)
+    dcos_api_session.cosmos.install_package('dcos-enterprise-cli', None, None)
 
     # Dictionary containing installed app-ids.
     app_ids = {}
@@ -386,15 +385,14 @@ def setup_workload(dcos_api_session, dcoscli, viptalk_app, viplisten_app, health
     dcos_api_session.marathon.wait_for_deployments_complete()
     log.info("Completed installing required services.")
 
-    dcoscli.exec_command("dcos package install cassandra --cli".split())
-    dcoscli.exec_command("dcos package install kafka --cli".split())
-    dcoscli.exec_command("dcos package install spark --cli".split())
+    dcoscli.exec_command("dcos package install cassandra --cli --yes".split())
+    dcoscli.exec_command("dcos package install kafka --cli --yes".split())
+    dcoscli.exec_command("dcos package install spark --cli --yes".split())
 
-    dcoscli.exec_command(["dcos", "cassandra", "plan", "status", "deploy", "--json"])
-    dcoscli.exec_command(["dcos", "cassandra", "plan", "status", "recovery", "--json"])
-    dcoscli.exec_command(["dcos", "kafka", "plan", "status", "deploy", "--json"])
-    dcoscli.exec_command(["dcos", "kafka", "plan", "status", "recovery", "--json"])
-
+    dcoscli.exec_command("dcos cassandra plan status deploy --json".split())
+    dcoscli.exec_command("dcos cassandra plan status recovery --json".split())
+    dcoscli.exec_command("dcos kafka plan status deploy --json".split())
+    dcoscli.exec_command("dcos kafka plan status recovery --json".split())
 
     dcoscli.exec_command(["dcos", "spark", "run", "--submit-args=" + spark_producer_job()])
     dcos_api_session.marathon.wait_for_deployments_complete()


### PR DESCRIPTION
Work for:
https://jira.mesosphere.com/browse/DCOS-39587

Create a test to run Kafka, Cassandra, and Spark, run two jobs on Spark that interact with Kafka, and read values from Kafka, thus exercising all three main frameworks.

Latest run of Code:
https://teamcity.mesosphere.io/viewLog.html?buildId=1161053&tab=buildResultsDiv&buildTypeId=DcOs_Enterprise_ManualTriggers_WipUpgradeTest_FromStable