### PR TITLE
Update Spark Scala test jar to one built with Scala 2.12.

### DIFF
--- a/json_job_definitions.py
+++ b/json_job_definitions.py
@@ -173,7 +173,7 @@ def spark_producer_job():
     return '"--conf spark.mesos.containerizer=mesos --conf spark.scheduler.maxRegisteredResourcesWaitingTime=2400s ' \
            '--conf spark.scheduler.minRegisteredResourcesRatio=1.0 --conf spark.cores.max=2 --conf ' \
            'spark.executor.cores=2 --conf spark.executor.mem=2g --conf spark.driver.mem=2g --class KafkaRandomFeeder ' \
-           'http://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.3.2-20190211-9c0dd2e' \
+           'http://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-3.0.1-20201223-b06cb01.jar' \
            '.jar --appName Producer --brokers kafka-0-broker.kafka.autoip.dcos.thisdcos.directory:1025,' \
            'kafka-1-broker.kafka.autoip.dcos.thisdcos.directory:1025,' \
            'kafka-2-broker.kafka.autoip.dcos.thisdcos.directory:1025 --topics mytopicC --numberOfWords 3600 ' \
@@ -182,7 +182,7 @@ def spark_producer_job():
 
 @pytest.fixture(scope='session')
 def spark_consumer_job():
-    return '"--conf spark.mesos.containerizer=mesos --conf spark.scheduler.maxRegisteredResourcesWaitingTime=2400s --conf spark.scheduler.minRegisteredResourcesRatio=1.0 --conf spark.cores.max=1 --conf spark.executor.cores=1 --conf spark.executor.mem=2g --conf spark.driver.mem=2g --conf spark.cassandra.connection.host=node-0-server.cassandra.autoip.dcos.thisdcos.directory --conf spark.cassandra.connection.port=9042 --class KafkaWordCount http://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.3.2-20190211-9c0dd2e.jar --appName Consumer --brokers kafka-0-broker.kafka.autoip.dcos.thisdcos.directory:1025,kafka-1-broker.kafka.autoip.dcos.thisdcos.directory:1025,kafka-2-broker.kafka.autoip.dcos.thisdcos.directory:1025 --topics mytopicC --groupId group1 --batchSizeSeconds 10 --cassandraKeyspace mykeyspace --cassandraTable mytable"'
+    return '"--conf spark.mesos.containerizer=mesos --conf spark.scheduler.maxRegisteredResourcesWaitingTime=2400s --conf spark.scheduler.minRegisteredResourcesRatio=1.0 --conf spark.cores.max=1 --conf spark.executor.cores=1 --conf spark.executor.mem=2g --conf spark.driver.mem=2g --conf spark.cassandra.connection.host=node-0-server.cassandra.autoip.dcos.thisdcos.directory --conf spark.cassandra.connection.port=9042 --class KafkaWordCount http://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-3.0.1-20201223-b06cb01.jar --appName Consumer --brokers kafka-0-broker.kafka.autoip.dcos.thisdcos.directory:1025,kafka-1-broker.kafka.autoip.dcos.thisdcos.directory:1025,kafka-2-broker.kafka.autoip.dcos.thisdcos.directory:1025 --topics mytopicC --groupId group1 --batchSizeSeconds 10 --cassandraKeyspace mykeyspace --cassandraTable mytable"'
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
The DC/OS Spark package was updated to Spark 3.0.0 which is built with Scala 2.12 and Scala 2.11 is [no longer supported](https://docs.d2iq.com/mesosphere/dcos/services/spark/2.12.0-3.0.1/release-notes/#updates).

This PR updates the Spark Test Jar to use one built with Scala 2.12.

For updating this libary in the future when Spark updates to new breaking Scala versions, the Spark Test Applications Library built from [spark-build](https://github.com/mesosphere/spark-build/tree/master/tests/jobs/scala) via this [Makefile](https://github.com/mesosphere/spark-build/blob/master/Makefile#L173-L186)

Once the target jar file is built, it should be moved from [this temporary location](https://github.com/mesosphere/spark-build/blob/135331ed9ebdeda3c34041de501ca987b03d4d37/Makefile#L181) to a permanent one at `http://infinity-artifacts.s3.amazonaws.com/scale-tests`
